### PR TITLE
Remove jinja delimiters from when statements fixing Ansible 2.3 warnings

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,7 +24,7 @@
   with_items: "{{ dockutil_removeditems.results }}"
   when:
   - dockitems_remove_all|bool == false
-  - '"{{ item.item }} was found in persistent-apps" in item.stdout'
+  - (item.item ~ " was found in persistent-apps") in item.stdout
 
 - name: Dockutil | Get information on configured setup
   shell: "dockutil --find '{{ item.name }}'"
@@ -37,7 +37,7 @@
   shell: "dockutil --add '{{ item.item.path }}' --position {{ item.item.pos }} --no-restart"
   register: added_items_task
   with_items: "{{ dockutil_newdata.results }}"
-  when: '"{{ item.item.name }} was not found in" in item.stdout'
+  when: (item.item.name ~ " was not found in") in item.stdout
 
 - name: Dockutil | Get information on current setup
   shell: "dockutil --find '{{ item.name }}'"
@@ -51,8 +51,8 @@
   register: moved_items_task
   with_items: "{{ dockutil_currdata.results }}"
   when:
-  - '"{{ item.item.name }} was found in persistent-apps at slot {{ item.item.pos }} in" not in item.stdout'
-  - '"{{ item.item.name }} was not found" not in item.stdout'
+  - (item.item.name ~ " was found in persistent-apps at slot " ~ item.item.pos ~ " in") not in item.stdout
+  - (item.item.name ~ " was not found") not in item.stdout
 
 - name: Dockutil | Restart Dock
   shell: "/usr/bin/killall Dock"


### PR DESCRIPTION
Fixes the following warnings in Ansible 2.3:

>TASK [fubarhouse.macdock : Dockutil | Adding items] **********************************************************************************************************************************************************************************************************
 [WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: "{{ item.item.name }} was not found in" in item.stdout
