### PR TITLE
Added failed_when on restart Dock handler

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,3 +2,4 @@
 # handlers file for fubarhouse.macdock
 - name: restart dock
   shell: "/usr/bin/killall Dock"
+  failed_when: false


### PR DESCRIPTION
I have added failed_when: false. It seems to do the trick with a quick test.
TBH, I don't understand the difference between failed_when: false and ignore_errors: yes, since both only look at the return code of the command. Syntax validation and so on should still give errors with both methods. At least if I understand the documentation correctly. I'd appreciate any advice or guidance here on a difference (mostly cause I like to learn and understand).

Fixes #6 